### PR TITLE
getCapability() should return LazyOptional.empty() instead of null

### DIFF
--- a/src/main/java/snownee/everpotion/cap/EverCapabilityProvider.java
+++ b/src/main/java/snownee/everpotion/cap/EverCapabilityProvider.java
@@ -6,6 +6,10 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.INBTSerializable;
 import net.minecraftforge.common.util.LazyOptional;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import snownee.everpotion.handler.EverHandler;
 
 public class EverCapabilityProvider implements ICapabilityProvider, INBTSerializable<CompoundNBT> {
@@ -19,9 +23,10 @@ public class EverCapabilityProvider implements ICapabilityProvider, INBTSerializ
         });
     }
 
+    @Nonnull
     @Override
-    public <T> LazyOptional<T> getCapability(Capability<T> cap, Direction side) {
-        return cap == EverCapabilities.HANDLER ? handler.cast() : null;
+    public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> cap,@Nullable Direction side) {
+        return EverCapabilities.HANDLER.orEmpty(cap, handler);
     }
 
     @Override


### PR DESCRIPTION
On 1.15 getCapability() should return LazyOptional.empty() instead of null, when it does return null minecraft will crash, producing a crash report similar to this one: https://hastebin.com/rajigopufu.pl 
